### PR TITLE
Update pvAIHelper.php to cast $temperature to a float as OpenAI requires - Fixes #221

### DIFF
--- a/func/pvAIHelper.php
+++ b/func/pvAIHelper.php
@@ -59,7 +59,10 @@ function pvAIHelper($prompt) {
     $model = $isGemini
         ? ($user_settings['google_gemini_model'] ?: 'gemini-2.0-flash')
         : ($user_settings['openai_model'] ?: 'gpt-4.1');
-    $temperature = $user_settings['openai_temperature'] ?: 0.7;
+    // OpenAI requires a temperature setting to always be a float    
+    $temperature = isset($user_settings['openai_temperature']) 
+        ? floatval($user_settings['openai_temperature']) 
+        : 0.7;
 
     if (empty($api_key)) {
         return ['error' => 'API key is not set'];


### PR DESCRIPTION
### Summary

Fixes #221 - Ensures the `temperature` value used in AI assistant calls is properly cast to a float before being sent to the OpenAI API.

### Changes

- Casts `$user_settings['openai_temperature']` to a float in `pvAIHelper.php`
- Prevents API schema validation errors due to passing a string instead of a decimal

### Testing

- Verified fix in local Docker container
- Triggered AI Fill for Notes with temperature slider set at various values - all requests succeeded without error